### PR TITLE
FI-2459: Limit Validation Messages

### DIFF
--- a/lib/bulk_data_test_kit/bulk_export_validation_tester.rb
+++ b/lib/bulk_data_test_kit/bulk_export_validation_tester.rb
@@ -143,6 +143,11 @@ module BulkDataTestKit
       skip_if (bulk_requires_access_token == 'true' && bearer_token.blank?),
               'Could not verify this functionality when Bearer Token is required and not provided'
 
+      $num_messages = 0
+      $capped_message = false
+      $num_errors = 0
+      $capped_errors = false
+
       assert_valid_json(bulk_status_output)
       
       full_file_list = JSON.parse(bulk_status_output)

--- a/lib/bulk_data_test_kit/v1.0.1/bulk_data_test_suite.rb
+++ b/lib/bulk_data_test_kit/v1.0.1/bulk_data_test_suite.rb
@@ -37,22 +37,33 @@ module BulkDataTestKit
 
         message_filters = VALIDATION_MESSAGE_FILTERS + VERSION_SPECIFIC_MESSAGE_FILTERS
 
-        num_messages = 0
-        capped_message = false
+        $num_messages = 0
+        $capped_message = false
+        $num_errors = 0
+        $capped_errors = false
+
         
         exclude_message do |message|
-          if message.type != 'error' then num_messages+=1 end
+          if message.type != 'error' 
+            $num_messages+=1 
+          else
+            $num_errors+=1 
+          end
+
           message_filters.any? { |filter| filter.match? message.message } ||
-          (message.type != 'error' && message.message != 'Only showing the first 50 validation info and warning messages.' && num_messages > 50)
+          (message.type != 'error' && $num_messages > 50 && !message.message.include?('Inferno is only showing the first')) ||
+          (message.type == 'error' && $num_errors > 20 && !message.message.include?('Inferno is only showing the first'))
         end
 
         perform_additional_validation do
-          if num_messages > 50 && !capped_message
-            capped_message = true
-            { type: 'info', message: 'Only showing the first 50 validation info and warning messages.'}
+          if $num_messages > 50 && !$capped_message
+            $capped_message = true
+            { type: 'info', message: 'Inferno is only showing the first 50 validation info and warning messages.'}
+          elsif $num_errors > 20 && !$capped_errors
+            $capped_errors = true
+            { type: 'error', message: 'Inferno is only showing the first 20 validation error messages.'}
           end
         end
-
       end
 
       def self.jwks_json

--- a/lib/bulk_data_test_kit/v1.0.1/bulk_data_valid_resources_test.rb
+++ b/lib/bulk_data_test_kit/v1.0.1/bulk_data_valid_resources_test.rb
@@ -12,7 +12,7 @@ module BulkDataTestKit
         This test verifies that the resources returned from bulk data export
         conform to the base FHIR standard. This includes checking for missing data
         elements and value set verification. This test caps the number of validation info and warning messages that
-        it will display to 50 messages.
+        it will display to 50 and the number of error messages it will display to 20.
       DESCRIPTION
 
       input :status_output

--- a/lib/bulk_data_test_kit/v2.0.0/bulk_data_test_suite.rb
+++ b/lib/bulk_data_test_kit/v2.0.0/bulk_data_test_suite.rb
@@ -37,19 +37,31 @@ module BulkDataTestKit
 
         message_filters = VALIDATION_MESSAGE_FILTERS + VERSION_SPECIFIC_MESSAGE_FILTERS
 
-        num_messages = 0
-        capped_message = false
+        $num_messages = 0
+        $capped_message = false
+        $num_errors = 0
+        $capped_errors = false
+
         
         exclude_message do |message|
-          if message.type != 'error' then num_messages+=1 end
+          if message.type != 'error'
+            $num_messages+=1 
+          else
+            $num_errors+=1 
+          end
+
           message_filters.any? { |filter| filter.match? message.message } ||
-          (message.type != 'error' && message.message != 'Only showing the first 50 validation info and warning messages.' && num_messages > 50)
+          (message.type != 'error' && $num_messages > 50 && !message.message.include?('Inferno is only showing the first')) ||
+          (message.type == 'error' && $num_errors > 20 && !message.message.include?('Inferno is only showing the first'))
         end
 
         perform_additional_validation do
-          if num_messages > 50 && !capped_message
-            capped_message = true
-            { type: 'info', message: 'Only showing the first 50 validation info and warning messages.'}
+          if $num_messages > 50 && !$capped_message
+            $capped_message = true
+            { type: 'info', message: 'Inferno is only showing the first 50 validation info and warning messages.'}
+          elsif $num_errors > 20 && !$capped_errors
+            $capped_errors = true
+            { type: 'error', message: 'Inferno is only showing the first 20 validation error messages.'}
           end
         end
       end


### PR DESCRIPTION
# Summary
The Bulk Data Test Kit produces too many validation messages that freeze up the UI. This PR limits the number of info and warning messages to 50 and the number of error messages to 20 to prevent this issue. If the validation messages reaches the cap, a message is added to the end that says that Inferno is only showing the first 50 validation info and warning messages or only showing the first 20 error messages.

# Testing Guidance
Run the bulk data test kit locally and run with a high validation resource count. Ensure that only 50 info and warning messages are produced, and that the UI does not freeze up. I used the BCDA server for testing: https://bcda.cms.gov/guide.html#try-the-api 
