### PR TITLE
Standardize validator env var

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,5 @@
 JS_HOST=""
-REDIS_URL=redis://localhost:6379/0
-INFERNO_HOST=http://localhost:4567
-
+REDIS_URL=redis://redis:6379/0
 
 # Full path to a custom JWKS json file, will use lib/bulk_data_test_kit/bulk_data_jwks.json if left blank
 # BULK_DATA_JWKS=

--- a/.env
+++ b/.env
@@ -1,6 +1,7 @@
 JS_HOST=""
-BULK_DATA_FHIR_RESOURCE_VALIDATOR_URL=http://hl7_validator_service:3500
-REDIS_URL=redis://redis:6379/0
+REDIS_URL=redis://localhost:6379/0
+INFERNO_HOST=http://localhost:4567
+
 
 # Full path to a custom JWKS json file, will use lib/bulk_data_test_kit/bulk_data_jwks.json if left blank
 # BULK_DATA_JWKS=

--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,3 @@
-BULK_DATA_FHIR_RESOURCE_VALIDATOR_URL=http://localhost/hl7validatorapi
+FHIR_RESOURCE_VALIDATOR_URL=http://localhost/hl7validatorapi
 REDIS_URL=redis://localhost:6379/0
 INFERNO_HOST=http://localhost:4567

--- a/.env.production
+++ b/.env.production
@@ -1,3 +1,3 @@
 REDIS_URL=redis://redis:6379/0
-BULK_DATA_FHIR_RESOURCE_VALIDATOR_URL=http://hl7_validator_service:3500
+FHIR_RESOURCE_VALIDATOR_URL=http://hl7_validator_service:3500
 INFERNO_HOST=http://localhost

--- a/.env.test
+++ b/.env.test
@@ -1,2 +1,2 @@
-BULK_DATA_VALIDATOR_URL=https://example.com/validatorapi
+FHIR_RESOURCE_VALIDATOR_URL=https://example.com/validatorapi
 ASYNC_JOBS=false

--- a/lib/bulk_data_test_kit/v1.0.1/bulk_data_test_suite.rb
+++ b/lib/bulk_data_test_kit/v1.0.1/bulk_data_test_suite.rb
@@ -33,8 +33,6 @@ module BulkDataTestKit
       VERSION_SPECIFIC_MESSAGE_FILTERS = [].freeze
 
       fhir_resource_validator do
-        url ENV.fetch('BULK_DATA_FHIR_RESOURCE_VALIDATOR_URL', 'http://hl7_validator_service:3500')
-
         message_filters = VALIDATION_MESSAGE_FILTERS + VERSION_SPECIFIC_MESSAGE_FILTERS
 
         $num_messages = 0

--- a/lib/bulk_data_test_kit/v2.0.0/bulk_data_test_suite.rb
+++ b/lib/bulk_data_test_kit/v2.0.0/bulk_data_test_suite.rb
@@ -33,8 +33,6 @@ module BulkDataTestKit
       VERSION_SPECIFIC_MESSAGE_FILTERS = [].freeze
 
       fhir_resource_validator do
-        url ENV.fetch('BULK_DATA_FHIR_RESOURCE_VALIDATOR_URL', 'http://hl7_validator_service:3500')
-
         message_filters = VALIDATION_MESSAGE_FILTERS + VERSION_SPECIFIC_MESSAGE_FILTERS
 
         $num_messages = 0


### PR DESCRIPTION
# Summary
Follow-on to #21 . Standardizes the environment variables used for the different test suites, now we can just use the default FHIR_RESOURCE_VALIDATOR_URL and remove the url line from the validator definition block

# Testing Guidance
There should be no visible impact to the env var change - sessions should start up and work when running via ruby or via docker