### PR TITLE
FI-2560 Bulk data preset update so tokens don't time out.

### DIFF
--- a/config/presets/bulk_data_v101_bulk_data_server.json
+++ b/config/presets/bulk_data_v101_bulk_data_server.json
@@ -1,0 +1,43 @@
+{
+  "title": "SMART Bulk Data Server",
+  "id": null,
+  "test_suite_id": "bulk_data_v101",
+  "inputs": [
+    {
+      "name": "bulk_server_url",
+      "type": "text",
+      "title": "Bulk Data FHIR URL",
+      "description": "The URL of the Bulk FHIR server.",
+      "value": "https://bulk-data.smarthealthit.org/eyJlcnIiOiIiLCJwYWdlIjoxMDAsImR1ciI6MTAsInRsdCI6NjAsIm0iOjEsInN0dSI6NCwiZGVsIjowLCJzZWN1cmUiOjF9/fhir"
+    },
+    {
+      "name": "backend_services_client_id",
+      "type": "text",
+      "title": "Bulk Data Client ID",
+      "description": "Client ID provided at registration to the Inferno application.",
+      "value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InJlZ2lzdHJhdGlvbi10b2tlbiJ9.eyJqd2tzX3VybCI6Imh0dHBzOi8vaW5mZXJuby5oZWFsdGhpdC5nb3Yvc3VpdGVzL2N1c3RvbS9idWxrX2RhdGFfdjEwMS8ud2VsbC1rbm93bi9qd2tzLmpzb24iLCJhY2Nlc3NUb2tlbnNFeHBpcmVJbiI6NjAsImlhdCI6MTcyNjUwMzU3N30.T6xomQ7aMfrnvQ_kC7S0aUgTQXzgDYDI3A-DIFBLH5g"
+    },
+    {
+      "name": "group_id",
+      "type": "text",
+      "title": "Group ID",
+      "description": "The Group ID associated with the group of patients to be exported.",
+      "value": "HealthNewEngland"
+    },
+    {
+      "name": "bulk_timeout",
+      "type": "text",
+      "title": "Export Times Out after (1-600)",
+      "description": "While testing, Inferno waits for the server to complete the exporting task.\n          If the calculated totalTime is greater than the timeout value specified here,\n          Inferno bulk client stops testing. Please enter an integer for the maximum wait time in seconds.\n          If timeout is less than 1, Inferno uses default value 180.\n          If the timeout is greater than 600 (10 minutes), Inferno uses the maximum value 600.",
+      "value": 180
+    },
+    {
+      "name": "lines_to_validate",
+      "type": "text",
+      "title": "Limit validation to a maximum resource count",
+      "description": "To validate all, leave blank.",
+      "optional": true,
+      "value": null
+    }
+  ]
+}

--- a/config/presets/bulk_data_v200_bulk_data_server.json
+++ b/config/presets/bulk_data_v200_bulk_data_server.json
@@ -1,0 +1,43 @@
+{
+  "title": "SMART Bulk Data Server",
+  "id": null,
+  "test_suite_id": "bulk_data_v200",
+  "inputs": [
+    {
+      "name": "bulk_server_url",
+      "type": "text",
+      "title": "Bulk Data FHIR URL",
+      "description": "The URL of the Bulk FHIR server.",
+      "value": "https://bulk-data.smarthealthit.org/eyJlcnIiOiIiLCJwYWdlIjoxMDAsImR1ciI6MTAsInRsdCI6NjAsIm0iOjEsInN0dSI6NCwiZGVsIjowLCJzZWN1cmUiOjF9/fhir"
+    },
+    {
+      "name": "backend_services_client_id",
+      "type": "text",
+      "title": "Bulk Data Client ID",
+      "description": "Client ID provided at registration to the Inferno application.",
+      "value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InJlZ2lzdHJhdGlvbi10b2tlbiJ9.eyJqd2tzX3VybCI6Imh0dHBzOi8vaW5mZXJuby5oZWFsdGhpdC5nb3Yvc3VpdGVzL2N1c3RvbS9idWxrX2RhdGFfdjEwMS8ud2VsbC1rbm93bi9qd2tzLmpzb24iLCJhY2Nlc3NUb2tlbnNFeHBpcmVJbiI6NjAsImlhdCI6MTcyNjUwMzU3N30.T6xomQ7aMfrnvQ_kC7S0aUgTQXzgDYDI3A-DIFBLH5g"
+    },
+    {
+      "name": "group_id",
+      "type": "text",
+      "title": "Group ID",
+      "description": "The Group ID associated with the group of patients to be exported.",
+      "value": "HealthNewEngland"
+    },
+    {
+      "name": "bulk_timeout",
+      "type": "text",
+      "title": "Export Times Out after (1-600)",
+      "description": "While testing, Inferno waits for the server to complete the exporting task.\n          If the calculated totalTime is greater than the timeout value specified here,\n          Inferno bulk client stops testing. Please enter an integer for the maximum wait time in seconds.\n          If timeout is less than 1, Inferno uses default value 180.\n          If the timeout is greater than 600 (10 minutes), Inferno uses the maximum value 600.",
+      "value": 180
+    },
+    {
+      "name": "lines_to_validate",
+      "type": "text",
+      "title": "Limit validation to a maximum resource count",
+      "description": "To validate all, leave blank.",
+      "optional": true,
+      "value": null
+    }
+  ]
+}


### PR DESCRIPTION
# Summary
The bulk data preset for the SMART Bulk Data Server (on inferno.healthit.gov) had a too-short time timeout for bearer tokens configured via their interface.  This PR creates presets with an hour long timeout for the bearer tokens.

Technically, these are a little off for use on localhost because it is hardcoded to the inferno.healthit.gov well-known jwks, but it is the same as on localhost and is what we do for g10, so I think its fine to include the presets here.

Also, they nicely added group ids that won't change, which makes the preset a lot more stable.  That is incorporated into the preset.

I will also be putting an equivalent update into inferno.healthit.gov's preset config.

# Testing Guidance

For both suites (bulk v1 and v2), use the 'SMART Bulk Data Server' and run Test 1 (auth) and Test 2.2 (group export).  The other exports don't work because their server is set up to export the whole DB.  Note that the tests will still fail due to other issues, but they will NOT fail anymore due to a token timeout.



