### PR TITLE
Release 0.12.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bulk_data_test_kit (0.11.1)
+    bulk_data_test_kit (0.11.2)
       bloomer (~> 1.0.0)
       colorize (~> 0.8.1)
       inferno_core (>= 0.6.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bulk_data_test_kit (0.11.2)
+    bulk_data_test_kit (0.12.0)
       bloomer (~> 1.0.0)
       colorize (~> 0.8.1)
       inferno_core (>= 0.6.7)

--- a/lib/bulk_data_test_kit/version.rb
+++ b/lib/bulk_data_test_kit/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module BulkDataTestKit
-  VERSION = '0.11.2'
+  VERSION = '0.12.0'
   LAST_UPDATED = '2025-03-25'
 end

--- a/lib/bulk_data_test_kit/version.rb
+++ b/lib/bulk_data_test_kit/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module BulkDataTestKit
-  VERSION = '0.11.1'
-  LAST_UPDATED = '2026-03-06'
+  VERSION = '0.11.2'
+  LAST_UPDATED = '2025-03-25'
 end


### PR DESCRIPTION
# Breaking Changes
This release updates the Bulk Data Test Kit to use AuthInfo rather than OAuthCredentials for storing auth information. As a result of this change, any test kits which rely on the Bulk Data Test Kit will need to be updated to use AuthInfo rather than OAuthCredentials inputs.