### PR TITLE
add input requirement to bulk_data_valid_resources_test.rb

### DIFF
--- a/lib/bulk_data_test_kit/v1.0.1/bulk_data_valid_resources_test.rb
+++ b/lib/bulk_data_test_kit/v1.0.1/bulk_data_valid_resources_test.rb
@@ -18,6 +18,7 @@ module BulkDataTestKit
         number of error messages it will display to 20.
       DESCRIPTION
 
+      input :smart_auth_info, type: :auth_info
       input :status_output
       input :requires_access_token
 


### PR DESCRIPTION
# Summary

It requires `smart_auth_info` for `perform_export_validation_test`, so it should be an input for the test.

I'm testing this to help me debug pdex test kit too

