### PR TITLE
Make $export routes more concrete

### DIFF
--- a/lib/bulk_data_test_kit/v2.0.0_client/endpoints/kick_off.rb
+++ b/lib/bulk_data_test_kit/v2.0.0_client/endpoints/kick_off.rb
@@ -59,7 +59,14 @@ module BulkDataTestKit
         end
 
         def request_type
-          (request.params[:type] || SYSTEM_EXPORT_TYPE).titleize
+          path_component_before_export = request.path_info.split('/')[-2].downcase
+          if path_component_before_export == 'fhir'
+            SYSTEM_EXPORT_TYPE
+          elsif path_component_before_export == 'patient'
+            PATIENT_EXPORT_TYPE
+          else
+            GROUP_EXPORT_TYPE
+          end
         end
 
         def group_id

--- a/lib/bulk_data_test_kit/v2.0.0_client/urls.rb
+++ b/lib/bulk_data_test_kit/v2.0.0_client/urls.rb
@@ -4,8 +4,8 @@ module BulkDataTestKit
   module BulkDataV200Client
     RESUME_PASS_ROUTE = '/resume_pass'
     BASE_ROUTE = '/fhir'
-    PATIENT_KICKOFF_ROUTE = "#{BASE_ROUTE}/:type/$export".freeze
-    GROUP_KICKOFF_ROUTE = "#{BASE_ROUTE}/:type/:group_id/$export".freeze
+    PATIENT_KICKOFF_ROUTE = "#{BASE_ROUTE}/Patient/$export".freeze
+    GROUP_KICKOFF_ROUTE = "#{BASE_ROUTE}/Group/:group_id/$export".freeze
     SYSTEM_KICKOFF_ROUTE = "#{BASE_ROUTE}/$export".freeze
     STATUS_ROUTE = '/status/:job_id'
     OUTPUT_ROUTE = "#{BASE_ROUTE}/Binary/:binary_id".freeze


### PR DESCRIPTION
# Summary

Previously, when adding client endpoints to other tests, route matching fails. Now, with a more concrete path, the matching works.